### PR TITLE
Fixed partition naming for soldered flash memory in repair_device.sh

### DIFF
--- a/repair_device.sh
+++ b/repair_device.sh
@@ -17,7 +17,7 @@ read -rp "Enter target disk (e.g., /dev/sda): " DISK
 DISK="${DISK:-/dev/sda}"
 
 # Determine if we need a partition suffix ("p" for NVMe, nothing for SATA/USB)
-if [[ "$DISK" =~ "nvme" ]]; then
+if [[ "$DISK" =~ "nvme" || "$DISK" =~ "mmcblk" ]]; then
   DISK_SUFFIX="p"
 else
   DISK_SUFFIX=""


### PR DESCRIPTION
I wanted to install on a device with soldered on flash memory and the script broke because it does not account for devices like /dev/mmcblk1. This only changes that these devices also get the suffix