### PR TITLE
Fix silent exit after disk confirmation (#6)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ This tool lets you install or repair SteamOS using **Valve’s official recovery
 - A patched version of `repair_device.sh`
 - A prompt to choose your install disk (e.g. `/dev/sda`)
 - Fixes the partition naming issue (`p` vs no-`p`) on non-NVMe drives
+- Works with or without a graphical session — falls back to terminal prompts when the zenity dialogs can't be shown
 
 ---
 
@@ -60,6 +61,11 @@ sudo ./repair_device.sh all
 You’ll be prompted to:
 - Enter the target disk (e.g. `/dev/sda`)
 - Confirm that you really want to wipe and reinstall SteamOS
+- Confirm the action a second time, either in a zenity dialog or — if no desktop
+  session is reachable — right in the terminal
+
+> The target (`all`, `system`, `home`, `chroot`, `sanitize`) is **required**.
+> Running `sudo ./repair_device.sh` with no target just prints the help text.
 
 ---
 
@@ -86,6 +92,48 @@ sudo chmod 000 /dev/nvme0n1
 - The script automatically detects whether your disk needs \`p\` in partition names (e.g. \`nvme0n1p1\` vs \`sda1\`)
 - You can tweak the script to skip formatting \`/home\`, disable BIOS updates, or jump into a chroot after install
 
+### Environment variables
+
+| Variable | Effect |
+|---|---|
+| `NOPROMPT=1` | Skip the confirmation dialogs entirely (unattended runs) |
+| `NOZENITY=1` | Always use terminal prompts, never zenity dialogs |
+| `POWEROFF=1` | Power off instead of rebooting when finished |
+| `HANG_ON_ERROR=1` | Stay on screen after an error instead of exiting (Valve's original behaviour) |
+
+---
+
+## 🩺 Troubleshooting
+
+### "Nothing happens after I pick my disk and type YES"
+
+Fixed. Older copies of this script exited without printing anything at that
+point, because the confirmation dialog is drawn by `zenity` and `zenity` cannot
+reach your desktop session when the script runs under `sudo` (`sudo` drops
+`XAUTHORITY` / `WAYLAND_DISPLAY`). The script ran with `set -e` but no `set -E`,
+so the failure aborted everything **without any error message at all**.
+
+The script now detects that case and asks for confirmation in the terminal
+instead. If you cloned the repo before this fix, just update:
+
+```bash
+cd steamos_custom_install
+git pull
+```
+
+You can also force terminal prompts at any time with `NOZENITY=1`.
+
+### The script fails part-way through
+
+Errors are now reported with the line number and the exact command that failed,
+e.g. `!! Failed at line 273 (exit 127): sfdisk "$DISK"`. Include that line when
+opening an issue — it says precisely where things went wrong.
+
+### "does not exist" / "is not a block device"
+
+Pass a **whole disk**, not a partition — `/dev/sda`, not `/dev/sda1`. Run
+`lsblk` to see what's attached.
+
 ---
 
 ## 🛠 What This Fixes (Compared to Valve’s Script)
@@ -93,8 +141,9 @@ sudo chmod 000 /dev/nvme0n1
 | Valve's Script                      | This Script                               |
 |------------------------------------|-------------------------------------------|
 | Hardcoded to `/dev/nvme0n1pX`      | Prompts for any disk (e.g. `/dev/sda`)    |
-| Crashes on external drives         | Fully stable on all device types          |
-| GUI-based (zenity)                 | Clean CLI interface                       |
+| Crashes on external drives         | Handles non-NVMe partition naming         |
+| Requires zenity + a desktop session | Falls back to terminal prompts            |
+| Hangs forever on error             | Reports the failing line and exits        |
 | Wipes disks with no confirmation   | Prompts before doing anything destructive |
 
 ---
@@ -104,7 +153,6 @@ sudo chmod 000 /dev/nvme0n1
 | File                | Description                                       |
 |---------------------|---------------------------------------------------|
 | `repair_device.sh`  | Main patched installer script with disk prompt    |
-| `repair_reimage.sh` | Simple wrapper for running `repair_device.sh all` |
 
 ---
 

--- a/repair_device.sh
+++ b/repair_device.sh
@@ -7,10 +7,43 @@
 # destructive if you have modified the expected partition layout.
 #
 
-set -eu
+# -E is required: without it the ERR trap below is NOT inherited by shell
+# functions, so a command failing inside one (e.g. zenity in prompt_step)
+# aborts the script with no output at all.
+set -euE
 
 die() { echo >&2 "!! $*"; exit 1; }
 readvar() { IFS= read -r -d '' "$1" || true; }
+
+# Validate the requested action *before* prompting for a disk, so that running
+# the script with no target (or a typo) prints the help text instead of asking
+# the user to confirm a destructive operation that is never going to run.
+TARGET="${1-help}"
+case "$TARGET" in
+  all|system|home|chroot|sanitize) ;;
+  *) TARGET=help ;;
+esac
+
+if [[ $TARGET = help ]]; then
+  cat >&2 <<'EOD'
+This tool can be used to reinstall or repair your SteamOS installation.
+
+Usage: sudo ./repair_device.sh <target>
+
+Possible targets:
+    all : permanently destroy all data on the target disk, and reinstall SteamOS.
+    system : reinstall SteamOS on the system partitions.
+    home : remove games and personalization.
+    chroot : chroot to the primary SteamOS partition set.
+    sanitize : perform an NVME sanitize operation.
+EOD
+  exit 1
+fi
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo >&2 "!! Please run as root, e.g. sudo ./repair_device.sh $TARGET"
+  exit 1
+fi
 
 # Prompt user for target disk (default to /dev/sda)
 read -rp "Enter target disk (e.g., /dev/sda): " DISK
@@ -24,6 +57,13 @@ else
 fi
 
 DOPARTVERIFY=1
+
+if [[ ! -b "$DISK" ]]; then
+  if [[ -e "$DISK" ]]; then
+    die "$DISK exists but is not a block device. Pass a whole disk such as /dev/sda (see 'lsblk')."
+  fi
+  die "$DISK does not exist. Run 'lsblk' to list the disks attached to this machine."
+fi
 
 echo "Target disk: $DISK"
 echo "Will use partitions like: ${DISK}${DISK_SUFFIX}1, ${DISK}${DISK_SUFFIX}2, ..."
@@ -67,10 +107,17 @@ diskpart() { echo "$DISK$DISK_SUFFIX$1"; }
 ## Util colors and such
 ##
 
+# Valve's original script blocks forever here because it runs under the OOBE
+# image where there is no shell to return to. This fork is launched from a
+# terminal, so report where we failed and exit instead of hanging silently.
+# Set HANG_ON_ERROR=1 to restore the original behaviour.
 err() {
+  local rc=$?
   echo >&2
+  eerr "Failed at line ${BASH_LINENO[0]} (exit $rc): ${BASH_COMMAND}"
   eerr "Imaging error occured, see above and restart process."
-  sleep infinity
+  [[ -z ${HANG_ON_ERROR:-} ]] || sleep infinity
+  exit "$rc"
 }
 trap err ERR
 
@@ -94,8 +141,21 @@ fmt_ext4()  { [[ $# -eq 2 && -n $1 && -n $2 ]] || die; cmd sudo mkfs.ext4 -F -L 
 fmt_fat32() { [[ $# -eq 2 && -n $1 && -n $2 ]] || die; cmd sudo mkfs.vfat -n"$1" "$2"; }
 
 ##
-## Prompt mechanics - currently using Zenity
+## Prompt mechanics - Zenity when a usable desktop session is present, plain
+## terminal prompts otherwise.
 ##
+
+# Can we actually put a GUI dialog on screen? Running the script under sudo
+# strips XAUTHORITY / WAYLAND_DISPLAY / XDG_RUNTIME_DIR from the environment, so
+# zenity is frequently present but unable to connect to the display. Probing it
+# once here means we fall back cleanly instead of dying mid-run.
+can_use_zenity()
+{
+  [[ -z ${NOZENITY:-} ]] || return 1
+  command -v zenity >/dev/null 2>&1 || return 1
+  [[ -n ${DISPLAY:-} || -n ${WAYLAND_DISPLAY:-} ]] || return 1
+  zenity --version >/dev/null 2>&1 || return 1
+}
 
 # Give the user a choice between Proceed, or Cancel (which exits this script)
 #  $1 Title
@@ -103,20 +163,34 @@ fmt_fat32() { [[ $# -eq 2 && -n $1 && -n $2 ]] || die; cmd sudo mkfs.vfat -n"$1"
 #
 prompt_step()
 {
-  title="$1"
-  msg="$2"
+  local title="$1"
+  local msg="$2"
   if [[ ${NOPROMPT:-} ]]; then
     echo -e "$msg"
     return 0
   fi
-  zenity --title "$title" --question --ok-label "Proceed" --cancel-label "Cancel" --no-wrap --text "$msg"
-  [[ $? = 0 ]] || exit 1
+
+  if can_use_zenity; then
+    if zenity --title "$title" --question --ok-label "Proceed" --cancel-label "Cancel" --no-wrap --text "$msg"; then
+      return 0
+    fi
+    die "Aborted by user"
+  fi
+
+  # Terminal fallback. Note the explicit `|| true` on read: without it, EOF on
+  # stdin would trip errexit and abort the script with no explanation.
+  local reply=""
+  echo
+  echo "== $title =="
+  echo -e "$msg"
+  echo
+  read -rp "Proceed? (type YES to continue): " reply || true
+  [[ "$reply" == "YES" ]] || die "Aborted by user"
 }
 
 prompt_reboot()
 {
-  prompt_step "Action Complete" "${1}\n\nChoose Proceed to reboot the Steam Deck now, or Cancel to stay in the repair image."
-  [[ $? = 0 ]] || exit 1
+  prompt_step "Action Complete" "${1}\n\nChoose Proceed to reboot now, or Cancel to stay in the repair image."
   if [[ ${POWEROFF:-} ]]; then
     cmd systemctl poweroff
   else
@@ -188,12 +262,7 @@ exithandler() {
 }
 trap exithandler EXIT
 
-# Check existence of target disk
-if [[ ! -e "$DISK" ]]; then
-  eerr "$DISK does not exist -- no nvme drive detected?"
-  sleep infinity
-  exit 1
-fi
+# Target disk existence is validated up front, right after it is entered.
 
 # Reinstall a fresh SteamOS copy.
 #
@@ -363,34 +432,13 @@ sanitize_all()
   echo "... sanitize done."
 }
 
-# print quick list of targets
-#
-help()
-{
-  readvar HELPMSG << EOD
-This tool can be used to reinstall or repair your SteamOS installation on a Steam Deck.
-
-Possible targets:
-    all : permanently destroy all data on your Steam Deck, and reinstall SteamOS.
-    system : reinstall SteamOS on the Steam Deck system partitions.
-    home : remove games and personalization from the Steam Deck.
-    chroot : chroot to the primary SteamOS partition set.
-    sanitize : perform an NVME sanitize operation.
-EOD
-  emsg "$HELPMSG"
-  if [[ "$EUID" -ne 0 ]]; then
-    eerr "Please run as root."
-    exit 1
-  fi
-}
-
-[[ "$EUID" -ne 0 ]] && help
-
 writePartitionTable=0
 writeOS=0
 writeHome=0
 
-case "${1-help}" in
+# $TARGET is validated at the top of the script, before anything destructive is
+# offered, so every branch below is a known-good target.
+case "$TARGET" in
 all)
   prompt_step "Reimage Steam Deck" "This action will reimage the Steam Deck.\nThis will permanently destroy all data on your Steam Deck and reinstall SteamOS.\n\nThis cannot be undone.\n\nChoose Proceed only if you wish to clear and reimage this device."
   writePartitionTable=1
@@ -418,7 +466,4 @@ sanitize)
   prompt_step "Clear and sanitize NVME disk" "This action will kick off an NVME sanitize on the Steam Deck, irrevocably deleting all user data.\n\nThis action cannot be undone.\n\nChoose Proceed only if you want to remove all data from the attached Steam Deck primary drive."
   sanitize_all
   ;;
-*)
-  help
-  ;;
-esac 
+esac


### PR DESCRIPTION
The script exited without printing anything after the user entered a disk
and typed YES. Two bugs combined to produce this:

1. `prompt_step` draws its confirmation via zenity. Under `sudo`, XAUTHORITY
   and WAYLAND_DISPLAY are stripped from the environment, so zenity cannot
   reach the desktop session and fails. `set -e` then aborted the run.
2. `trap err ERR` is not inherited by shell functions unless `set -E` is also
   set. Because the failure happened inside `prompt_step`, the error handler
   never ran and the script died with no output whatsoever.

Changes:

- Enable `set -E` so the ERR trap fires inside functions.
- Probe zenity for usability and fall back to a terminal confirmation prompt
  when it is missing or cannot reach a display. `NOZENITY=1` forces this path.
- Report the failing line, exit code and command on error, then exit instead
  of blocking on `sleep infinity`. `HANG_ON_ERROR=1` restores the old
  behaviour for the OOBE image, where there is no shell to return to.
- Validate the target argument and root privileges before prompting for a
  disk, so a missing or mistyped target prints help instead of asking the
  user to confirm an operation that will never run.
- Require the target to be a block device and give an actionable message
  pointing at `lsblk` when it is not.
- Drop the now-unreachable duplicate help/EUID handling at the bottom.

Document the fix, the supported environment variables and a troubleshooting
section in the readme, and drop the reference to `repair_reimage.sh`, which
is not in the repository.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bf46SL2MvmLsGeqmjtCaUW